### PR TITLE
README adjustments to quickly call out the repro creation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,24 @@ Unfortunately, describing an error in GitHub is often not enough to truly unders
 
 This repo was created with [`create-react-app`][2] for a great developer experience. If you are not using React then a small reproduction case with your framework of choice would go a long way.
 
-To get started writing your error case just clone this repository to your GitHub account, install all dependencies with `npm install`, start the development server with `npm start`, make the changes that will reproduce this error locally, and push your changes to GitHub where the `apollo-client` team can see them.
-
 To make changes in the GraphQL schema make sure to look at the `./src/graphql` folder where we define a GraphQL schema using [GraphQL.js][3] which will run in the browser.
 
 [1]: https://github.com/apollographql/apollo-client
 [2]: https://github.com/facebookincubator/create-react-app
 [3]: http://graphql.org/graphql-js/
 
+# Reproduction Creation Steps
+
+1. Fork this repository to your GitHub account.
+2. After cloning, install all dependencies with `npm install`.
+3. Start the development server with `npm start`.
+4. Make the changes that will reproduce this error locally.
+5. When ready, push your changes back to GitHub and let the `apollo-client` team know where they can be found.
+
 # Deploy to Github Pages
-You can deploy your built error demo to gh-pages branch by running:
+
+You can deploy your built error demo to a `gh-pages` branch by running:
+
 ```
 npm run deploy YOUR_GIT_REMOTE
 ```


### PR DESCRIPTION
The reproduction creation steps were a bit buried in paragraph form. Calling the steps out in a list should be easier to follow for newcomers.
