### PR TITLE
Demonstrate how to replace __DEV__ with false in production builds.

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -8,7 +8,7 @@ const webpack = require("webpack");
 module.exports = override(
   addWebpackPlugin(
     new webpack.DefinePlugin({
-      __DEV__: JSON.stringify(false),
+      __DEV__: JSON.stringify(process.env.NODE_ENV !== "production"),
     }),
   ),
 );

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,0 +1,14 @@
+const {
+  override,
+  addWebpackPlugin,
+} = require("customize-cra");
+
+const webpack = require("webpack");
+
+module.exports = override(
+  addWebpackPlugin(
+    new webpack.DefinePlugin({
+      __DEV__: JSON.stringify(false),
+    }),
+  ),
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "react-dom": "^17.0.2"
       },
       "devDependencies": {
+        "customize-cra": "^1.0.0",
+        "react-app-rewired": "^2.1.8",
         "react-scripts": "^4.0.3"
       }
     },
@@ -6440,6 +6442,15 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
+    },
+    "node_modules/customize-cra": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/customize-cra/-/customize-cra-1.0.0.tgz",
+      "integrity": "sha512-DbtaLuy59224U+xCiukkxSq8clq++MOtJ1Et7LED1fLszWe88EoblEYFBJ895sB1mC6B4uu3xPT/IjClELhMbA==",
+      "dev": true,
+      "dependencies": {
+        "lodash.flow": "^3.5.0"
+      }
     },
     "node_modules/cyclist": {
       "version": "1.0.1",
@@ -13500,6 +13511,12 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "node_modules/lodash.flow": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
+      "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o=",
+      "dev": true
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -16983,6 +17000,30 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-app-rewired": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.8.tgz",
+      "integrity": "sha512-wjXPdKPLscA7mn0I1de1NHrbfWdXz4S1ladaGgHVKdn1hTgKK5N6EdGIJM0KrS6bKnJBj7WuqJroDTsPKKr66Q==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^5.6.0"
+      },
+      "bin": {
+        "react-app-rewired": "bin/index.js"
+      },
+      "peerDependencies": {
+        "react-scripts": ">=2.1.3"
+      }
+    },
+    "node_modules/react-app-rewired/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/react-dev-utils": {
@@ -27930,6 +27971,15 @@
         }
       }
     },
+    "customize-cra": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/customize-cra/-/customize-cra-1.0.0.tgz",
+      "integrity": "sha512-DbtaLuy59224U+xCiukkxSq8clq++MOtJ1Et7LED1fLszWe88EoblEYFBJ895sB1mC6B4uu3xPT/IjClELhMbA==",
+      "dev": true,
+      "requires": {
+        "lodash.flow": "^3.5.0"
+      }
+    },
     "cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
@@ -33468,6 +33518,12 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.flow": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
+      "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -36342,6 +36398,23 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.7",
         "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "react-app-rewired": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.8.tgz",
+      "integrity": "sha512-wjXPdKPLscA7mn0I1de1NHrbfWdXz4S1ladaGgHVKdn1hTgKK5N6EdGIJM0KrS6bKnJBj7WuqJroDTsPKKr66Q==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
+    "customize-cra": "^1.0.0",
+    "react-app-rewired": "^2.1.8",
     "react-scripts": "^4.0.3"
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-app-rewired build",
     "test": "react-scripts test --env=jsdom"
   },
   "browserslist": [


### PR DESCRIPTION
When using a version of `@apollo/client` with https://github.com/apollographql/apollo-client/pull/8347 applied, this configuration saves a whopping 3.73kB of minified+gzip code (due to removing development-only code) when running `npm run build` to generate an optimized production build, without requiring CRA ejection.

@hwillson @brainkim If we land https://github.com/apollographql/apollo-client/pull/8347 for Apollo Client v3.4, this configuration will most likely be what we recommend to Create React App folks, so I'm open to any ways we might be able to simplify it further.