### PR TITLE
Avoid unnecessary `JSON.stringify` with `webpack.DefinePlugin`

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -8,7 +8,7 @@ const webpack = require("webpack");
 module.exports = override(
   addWebpackPlugin(
     new webpack.DefinePlugin({
-      __DEV__: JSON.stringify(process.env.NODE_ENV !== "production"),
+      __DEV__: process.env.NODE_ENV !== "production",
     }),
   ),
 );


### PR DESCRIPTION
Follow-up to #51.

Although a string will be handled correctly (as a code fragment), using `JSON.stringify` only seems to be necessary when the original value is already a string, to preserve the quotation marks: https://webpack.js.org/plugins/define-plugin/#usage

I verified with `npm run build` that this change has no effect on the total bundle size of the production build.