### PR TITLE
Pass named options to `graphql` function

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -65,14 +65,12 @@ const link = new ApolloLink(operation => {
     const { query, operationName, variables } = operation;
     await delay(300);
     try {
-      const result = await graphql(
+      const result = await graphql({
         schema,
-        print(query),
-        null,
-        null,
-        variables,
+        source: print(query),
+        variableValues: variables,
         operationName,
-      );
+      });
       observer.next(result);
       observer.complete();
     } catch (err) {


### PR DESCRIPTION
Similar to changes made by @brainkim in https://github.com/apollographql/apollo-client/pull/8997, this commit fixes the React Apollo template application when built with graphql@16, since support for passing positional arguments was removed in https://github.com/graphql/graphql-js/pull/2904. The named options style also works with `graphql@15`.