### PR TITLE
Update error template to fix Codesandbox issues 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "graphql"
+        # Currently the graphql module seems to break on Codesandbox when 
+        # over version 16, so we'll keep it on 15.x until this is resolved.
+        # See issue apollo-client/#9943.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "@apollo/client": "^3.6.8",
-    "graphql": "^16.4.0",
+    "graphql": "^15.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "apollo-client-error-template",
   "version": "1.0.0",
   "license": "MIT",
+  "main": "src/index.jsx",
   "dependencies": {
     "@apollo/client": "^3.6.8",
     "graphql": "^15.6.1",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,84 +1,3 @@
-/*** SCHEMA ***/
-import {
-  GraphQLSchema,
-  GraphQLObjectType,
-  GraphQLID,
-  GraphQLString,
-  GraphQLList,
-} from 'graphql';
-const PersonType = new GraphQLObjectType({
-  name: 'Person',
-  fields: {
-    id: { type: GraphQLID },
-    name: { type: GraphQLString },
-  },
-});
-
-const peopleData = [
-  { id: 1, name: 'John Smith' },
-  { id: 2, name: 'Sara Smith' },
-  { id: 3, name: 'Budd Deey' },
-];
-
-const QueryType = new GraphQLObjectType({
-  name: 'Query',
-  fields: {
-    people: {
-      type: new GraphQLList(PersonType),
-      resolve: () => peopleData,
-    },
-  },
-});
-
-const MutationType = new GraphQLObjectType({
-  name: 'Mutation',
-  fields: {
-    addPerson: {
-      type: PersonType,
-      args: {
-        name: { type: GraphQLString },
-      },
-      resolve: function (_, { name }) {
-        const person = {
-          id: peopleData[peopleData.length - 1].id + 1,
-          name,
-        };
-
-        peopleData.push(person);
-        return person;
-      }
-    },
-  },
-});
-
-const schema = new GraphQLSchema({ query: QueryType, mutation: MutationType });
-
-/*** LINK ***/
-import { graphql, print } from "graphql";
-import { ApolloLink, Observable } from "@apollo/client";
-function delay(wait) {
-  return new Promise(resolve => setTimeout(resolve, wait));
-}
-
-const link = new ApolloLink(operation => {
-  return new Observable(async observer => {
-    const { query, operationName, variables } = operation;
-    await delay(300);
-    try {
-      const result = await graphql({
-        schema,
-        source: print(query),
-        variableValues: variables,
-        operationName,
-      });
-      observer.next(result);
-      observer.complete();
-    } catch (err) {
-      observer.error(err);
-    }
-  });
-});
-
 /*** APP ***/
 import React, { useState } from "react";
 import { createRoot } from "react-dom/client";
@@ -90,6 +9,8 @@ import {
   useQuery,
   useMutation,
 } from "@apollo/client";
+
+import { link } from "./link.js";
 import "./index.css";
 
 const ALL_PEOPLE = gql`

--- a/src/link.js
+++ b/src/link.js
@@ -1,0 +1,27 @@
+/*** LINK ***/
+import { graphql, print } from "graphql";
+import { ApolloLink, Observable } from "@apollo/client";
+import { schema } from "./schema.js";
+
+function delay(wait) {
+  return new Promise(resolve => setTimeout(resolve, wait));
+}
+
+export const link = new ApolloLink(operation => {
+  return new Observable(async observer => {
+    const { query, operationName, variables } = operation;
+    await delay(300);
+    try {
+      const result = await graphql({
+        schema,
+        source: print(query),
+        variableValues: variables,
+        operationName,
+      });
+      observer.next(result);
+      observer.complete();
+    } catch (err) {
+      observer.error(err);
+    }
+  });
+});

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,0 +1,55 @@
+/*** SCHEMA ***/
+import {
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLID,
+  GraphQLString,
+  GraphQLList,
+} from 'graphql';
+
+const PersonType = new GraphQLObjectType({
+  name: 'Person',
+  fields: {
+    id: { type: GraphQLID },
+    name: { type: GraphQLString },
+  },
+});
+
+const peopleData = [
+  { id: 1, name: 'John Smith' },
+  { id: 2, name: 'Sara Smith' },
+  { id: 3, name: 'Budd Deey' },
+];
+
+const QueryType = new GraphQLObjectType({
+  name: 'Query',
+  fields: {
+    people: {
+      type: new GraphQLList(PersonType),
+      resolve: () => peopleData,
+    },
+  },
+});
+
+const MutationType = new GraphQLObjectType({
+  name: 'Mutation',
+  fields: {
+    addPerson: {
+      type: PersonType,
+      args: {
+        name: { type: GraphQLString },
+      },
+      resolve: function (_, { name }) {
+        const person = {
+          id: peopleData[peopleData.length - 1].id + 1,
+          name,
+        };
+
+        peopleData.push(person);
+        return person;
+      }
+    },
+  },
+});
+
+export const schema = new GraphQLSchema({ query: QueryType, mutation: MutationType });


### PR DESCRIPTION
Per these issues: https://github.com/apollographql/apollo-client/issues/9846 and https://github.com/apollographql/apollo-client/issues/9659, it looks like `graphql` version `16` doesn't work on Codesandbox. This PR updates the package.json and dependabot config to keep it on version 15.6.1 until this is resolved.

Furthermore, this manually sets `index.jsx` as the default entrypoint, as it looks like `create-react-app` no longer automatically looks at `.jsx` files for entrypoints. 

Codesandbox for this PR: https://codesandbox.io/s/react-apollo-error-template-mdbfix-vtfnw4

PS: Also this splits the Link and Schema definition into their own files, as having everything in one long chunk seemed against the sensibilities of both ESLint and myself. LMK if I should revert this change.