### PR TITLE
Bump GraphQL version 15.6.1 -> 16.6.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,3 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    ignore:
-      - dependency-name: "graphql"
-        # Currently the graphql module seems to break on Codesandbox when 
-        # over version 16, so we'll keep it on 15.x until this is resolved.
-        # See issue apollo-client/#9943.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.jsx",
   "dependencies": {
     "@apollo/client": "^3.6.8",
-    "graphql": "^15.6.1",
+    "graphql": "^16.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
https://github.com/apollographql/react-apollo-error-template/pull/119 Downgraded the GraphQL dependency to v15 as a workaround for https://github.com/graphql/graphql-js/issues/3685#event-7200029936, an issue where a TypeError was being thrown and preventing users from using the error-reporting codesandbox. 

https://github.com/graphql/graphql-js/pull/3686 has fixed that issue, so we can now re-bump GraphQL to v16. Also updates the dependabot config to reflect this. 

<!--**Pull Request Labels**


While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->