### PR TITLE
Add subscription (GraphQLWSLink) example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@apollo/client": "^3.7.9",
-        "graphql": "^16.6.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "@apollo/client": "3.7.9",
+        "graphql": "16.6.0",
+        "graphql-ws": "5.11.3",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "react-router-dom": "6.8.1"
       },
       "devDependencies": {
         "customize-cra": "^1.0.0",
@@ -3045,6 +3047,14 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.2.tgz",
+      "integrity": "sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -8435,6 +8445,17 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/graphql-ws": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.11.3.tgz",
+      "integrity": "sha512-fU8zwSgAX2noXAsuFiCZ8BtXeXZOzXyK5u1LloCdacsVth4skdBMPO74EG51lBoWSIZ8beUocdpV8+cQHBODnQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
@@ -14432,6 +14453,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.1.tgz",
+      "integrity": "sha512-Jgi8BzAJQ8MkPt8ipXnR73rnD7EmZ0HFFb7jdQU24TynGW1Ooqin2KVDN9voSC+7xhqbbCd2cjGUepb6RObnyg==",
+      "dependencies": {
+        "@remix-run/router": "1.3.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.1.tgz",
+      "integrity": "sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==",
+      "dependencies": {
+        "@remix-run/router": "1.3.2",
+        "react-router": "6.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -19864,6 +19915,11 @@
         }
       }
     },
+    "@remix-run/router": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.2.tgz",
+      "integrity": "sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA=="
+    },
     "@rollup/plugin-babel": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
@@ -23974,6 +24030,12 @@
           "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
+    },
+    "graphql-ws": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.11.3.tgz",
+      "integrity": "sha512-fU8zwSgAX2noXAsuFiCZ8BtXeXZOzXyK5u1LloCdacsVth4skdBMPO74EG51lBoWSIZ8beUocdpV8+cQHBODnQ==",
+      "requires": {}
     },
     "gzip-size": {
       "version": "6.0.0",
@@ -28314,6 +28376,23 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "dev": true
+    },
+    "react-router": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.1.tgz",
+      "integrity": "sha512-Jgi8BzAJQ8MkPt8ipXnR73rnD7EmZ0HFFb7jdQU24TynGW1Ooqin2KVDN9voSC+7xhqbbCd2cjGUepb6RObnyg==",
+      "requires": {
+        "@remix-run/router": "1.3.2"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.1.tgz",
+      "integrity": "sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==",
+      "requires": {
+        "@remix-run/router": "1.3.2",
+        "react-router": "6.8.1"
+      }
     },
     "react-scripts": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "license": "MIT",
   "main": "src/index.jsx",
   "dependencies": {
-    "@apollo/client": "^3.7.9",
-    "graphql": "^16.6.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "@apollo/client": "3.7.9",
+    "graphql": "16.6.0",
+    "graphql-ws": "5.11.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-router-dom": "6.8.1"
   },
   "devDependencies": {
     "customize-cra": "^1.0.0",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,5 +1,6 @@
 /*** APP ***/
 import React, { useState } from "react";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { createRoot } from "react-dom/client";
 import {
   ApolloClient,
@@ -11,6 +12,8 @@ import {
 } from "@apollo/client";
 
 import { link } from "./link.js";
+import { Subscriptions } from "./subscriptions.jsx";
+import { Layout } from "./layout.jsx";
 import "./index.css";
 
 const ALL_PEOPLE = gql`
@@ -32,11 +35,8 @@ const ADD_PERSON = gql`
 `;
 
 function App() {
-  const [name, setName] = useState('');
-  const {
-    loading,
-    data,
-  } = useQuery(ALL_PEOPLE);
+  const [name, setName] = useState("");
+  const { loading, data } = useQuery(ALL_PEOPLE);
 
   const [addPerson] = useMutation(ADD_PERSON, {
     update: (cache, { data: { addPerson: addPersonData } }) => {
@@ -46,10 +46,7 @@ function App() {
         query: ALL_PEOPLE,
         data: {
           ...peopleResult,
-          people: [
-            ...peopleResult.people,
-            addPersonData,
-          ],
+          people: [...peopleResult.people, addPersonData],
         },
       });
     },
@@ -57,22 +54,18 @@ function App() {
 
   return (
     <main>
-      <h1>Apollo Client Issue Reproduction</h1>
-      <p>
-        This application can be used to demonstrate an error in Apollo Client.
-      </p>
       <div className="add-person">
         <label htmlFor="name">Name</label>
         <input
           type="text"
           name="name"
           value={name}
-          onChange={evt => setName(evt.target.value)}
+          onChange={(evt) => setName(evt.target.value)}
         />
         <button
           onClick={() => {
             addPerson({ variables: { name } });
-            setName('');
+            setName("");
           }}
         >
           Add person
@@ -83,7 +76,7 @@ function App() {
         <p>Loading…</p>
       ) : (
         <ul>
-          {data?.people.map(person => (
+          {data?.people.map((person) => (
             <li key={person.id}>{person.name}</li>
           ))}
         </ul>
@@ -94,13 +87,21 @@ function App() {
 
 const client = new ApolloClient({
   cache: new InMemoryCache(),
-  link
+  link,
 });
 
 const container = document.getElementById("root");
 const root = createRoot(container);
+
 root.render(
   <ApolloProvider client={client}>
-    <App />
+    <Router>
+      <Routes>
+        <Route path="/" element={<Layout />}>
+          <Route index element={<App />} />
+          <Route path="subscriptions-wslink" element={<Subscriptions />} />
+        </Route>
+      </Routes>
+    </Router>
   </ApolloProvider>
 );

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -54,6 +54,7 @@ function App() {
 
   return (
     <main>
+      <h3>Home</h3>
       <div className="add-person">
         <label htmlFor="name">Name</label>
         <input

--- a/src/layout.jsx
+++ b/src/layout.jsx
@@ -1,0 +1,30 @@
+import { Outlet, Link } from "react-router-dom";
+
+export function Layout() {
+  return (
+    <div className="App">
+      <header className="App-header">
+        <h1>Apollo Client Issue Reproduction</h1>
+        <p>
+          This application can be used to demonstrate an error in Apollo Client.
+        </p>
+
+        <nav>
+          <ul>
+            <li>
+              <Link to="/">Home</Link>
+            </li>
+            <li>
+              <Link to="/subscriptions-wslink">
+                Subscriptions (GraphQLWsLink)
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      </header>
+      <div className="Grid-column">
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/src/link.js
+++ b/src/link.js
@@ -28,7 +28,7 @@ const staticDataLink = new ApolloLink((operation) => {
   });
 });
 
-const url = "wss://nyx00g.sse.codesandbox.io/graphql";
+const url = "wss://uifesi.sse.codesandbox.io/graphql";
 
 const wsLink = new GraphQLWsLink(
   createClient({

--- a/src/link.js
+++ b/src/link.js
@@ -40,9 +40,10 @@ const definitionIsSubscription = (d) => {
   return d.kind === "OperationDefinition" && d.operation === "subscription";
 };
 
-// Create a bidirectional link in order to use different terminating links
-// depending on the operation type: a WebSocket for subscriptions and our own
+// Use directional composition in order to customize the terminating link
+// based on operation type: a WebSocket for subscriptions and our own
 // custom ApolloLink for everything else.
+// For more information, see: https://www.apollographql.com/docs/react/api/link/introduction/#directional-composition
 export const link = ApolloLink.split(
   (operation) => operation.query.definitions.some(definitionIsSubscription),
   wsLink,

--- a/src/link.js
+++ b/src/link.js
@@ -1,14 +1,16 @@
 /*** LINK ***/
 import { graphql, print } from "graphql";
 import { ApolloLink, Observable } from "@apollo/client";
+import { createClient } from "graphql-ws";
+import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
 import { schema } from "./schema.js";
 
 function delay(wait) {
-  return new Promise(resolve => setTimeout(resolve, wait));
+  return new Promise((resolve) => setTimeout(resolve, wait));
 }
 
-export const link = new ApolloLink(operation => {
-  return new Observable(async observer => {
+const staticDataLink = new ApolloLink((operation) => {
+  return new Observable(async (observer) => {
     const { query, operationName, variables } = operation;
     await delay(300);
     try {
@@ -25,3 +27,24 @@ export const link = new ApolloLink(operation => {
     }
   });
 });
+
+const url = "wss://nyx00g.sse.codesandbox.io/graphql";
+
+const wsLink = new GraphQLWsLink(
+  createClient({
+    url,
+  })
+);
+
+const definitionIsSubscription = (d) => {
+  return d.kind === "OperationDefinition" && d.operation === "subscription";
+};
+
+// Create a bidirectional link in order to use different terminating links
+// depending on the operation type: a WebSocket for subscriptions and our own
+// custom ApolloLink for everything else.
+export const link = ApolloLink.split(
+  (operation) => operation.query.definitions.some(definitionIsSubscription),
+  wsLink,
+  staticDataLink
+);

--- a/src/subscriptions.jsx
+++ b/src/subscriptions.jsx
@@ -1,0 +1,42 @@
+import { gql, useSubscription } from "@apollo/client";
+
+const query = gql`
+  subscription {
+    numberIncremented
+  }
+`;
+
+export function Subscriptions() {
+  const { data, error, loading } = useSubscription(query);
+  if (loading) return <p>Loading...</p>;
+  if (error) return <SubscriptionError />
+  return (
+    <>
+      <h3>Response: </h3>
+      <p>Score: {data?.numberIncremented}</p>
+    </>
+  );
+}
+
+function SubscriptionError() {
+  return (
+    <>
+      <p>Error :(</p>
+      <p>
+        The CodeSandbox serving our WebSocket API may be sleeping, please
+        visit{" "}
+        <a href="https://nyx00g.sse.codesandbox.io/graphql" target="_blank">
+          https://nyx00g.sse.codesandbox.io/graphql
+        </a>{" "}
+        to wake it up. Once you see the{" "}
+        <a
+          href="https://www.apollographql.com/docs/graphos/explorer/explorer/"
+          target="_blank"
+        >
+          Apollo Studio Explorer
+        </a>{" "}
+        IDE at the link above, you can refresh this page.
+      </p>
+    </>
+  );
+}

--- a/src/subscriptions.jsx
+++ b/src/subscriptions.jsx
@@ -30,8 +30,8 @@ function SubscriptionError() {
       <p>Error :(</p>
       <p>
         The CodeSandbox serving our WebSocket API may be sleeping, please visit{" "}
-        <a href="https://nyx00g.sse.codesandbox.io/graphql" target="_blank">
-          https://nyx00g.sse.codesandbox.io/graphql
+        <a href="https://uifesi.sse.codesandbox.io/graphql" target="_blank">
+          https://uifesi.sse.codesandbox.io/graphql
         </a>{" "}
         to wake it up.
       </p>

--- a/src/subscriptions.jsx
+++ b/src/subscriptions.jsx
@@ -9,11 +9,17 @@ const query = gql`
 export function Subscriptions() {
   const { data, error, loading } = useSubscription(query);
   if (loading) return <p>Loading...</p>;
-  if (error) return <SubscriptionError />
   return (
     <>
-      <h3>Response: </h3>
-      <p>Score: {data?.numberIncremented}</p>
+      <h3>Subscriptions</h3>
+      {error ? (
+        <SubscriptionError />
+      ) : (
+        <>
+          <h4>Response: </h4>
+          <p>Score: {data?.numberIncremented}</p>
+        </>
+      )}
     </>
   );
 }
@@ -23,12 +29,14 @@ function SubscriptionError() {
     <>
       <p>Error :(</p>
       <p>
-        The CodeSandbox serving our WebSocket API may be sleeping, please
-        visit{" "}
+        The CodeSandbox serving our WebSocket API may be sleeping, please visit{" "}
         <a href="https://nyx00g.sse.codesandbox.io/graphql" target="_blank">
           https://nyx00g.sse.codesandbox.io/graphql
         </a>{" "}
-        to wake it up. Once you see the{" "}
+        to wake it up.
+      </p>
+      <p>
+        Once you see the{" "}
         <a
           href="https://www.apollographql.com/docs/graphos/explorer/explorer/"
           target="_blank"


### PR DESCRIPTION
This PR adds basic routing and a subscription example using `GraphQLWsLink`.

## Homepage
![CleanShot 2023-02-22 at 10 14 07](https://user-images.githubusercontent.com/5139846/220668322-b104d333-2c8c-4510-ba63-155445004015.png)

## Subscriptions page - error with instructions on waking the CodeSandbox to provide the WS back-end
![CleanShot 2023-02-22 at 10 13 04](https://user-images.githubusercontent.com/5139846/220668431-f111eb2e-6655-4092-a0e7-544d2c59c964.png)

## Once you click the link and refresh, you see an Apollo Studio Explorer instance
![CleanShot 2023-02-22 at 10 13 44](https://user-images.githubusercontent.com/5139846/220668582-12c93331-0598-421e-b04b-6203cc277b6e.png)

## When you return, 🎉 you have a running subscription
![CleanShot 2023-02-22 at 10 13 56](https://user-images.githubusercontent.com/5139846/220668749-906150a5-bb35-4eaf-897f-c43ac6c6a608.png)
