### PR TITLE
fix `async` subscriber

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -10,21 +10,23 @@ function delay(wait) {
 }
 
 const staticDataLink = new ApolloLink((operation) => {
-  return new Observable(async (observer) => {
-    const { query, operationName, variables } = operation;
-    await delay(300);
-    try {
-      const result = await graphql({
-        schema,
-        source: print(query),
-        variableValues: variables,
-        operationName,
-      });
-      observer.next(result);
-      observer.complete();
-    } catch (err) {
-      observer.error(err);
-    }
+  return new Observable((observer) => {
+    Promise.then(async () => {
+      const { query, operationName, variables } = operation;
+      await delay(300);
+      try {
+        const result = await graphql({
+          schema,
+          source: print(query),
+          variableValues: variables,
+          operationName,
+        });
+        observer.next(result);
+        observer.complete();
+      } catch (err) {
+        observer.error(err);
+      }
+    });
   });
 });
 


### PR DESCRIPTION
While this seems to work with zen-observable, with rxjs this will cause 
![image](https://github.com/user-attachments/assets/7a336695-7d96-4922-b5eb-1d4356def5a5)
